### PR TITLE
JS: Uncaught SyntaxError: Invalid shorthand property initializer

### DIFF
--- a/.github/workflows/codeqa-test.yml
+++ b/.github/workflows/codeqa-test.yml
@@ -21,16 +21,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.8, pypy3]
+        python-version: [3.6, 3.8, pypy3.8]
         sphinx-version: [2.4.4, 3.2.1, 5.2.3]
         exclude:
           - python-version: 3.8
             sphinx-version: 2.4.4
-          - python-version: pypy3
+          - python-version: pypy3.8
             sphinx-version: 2.4.4
           - python-version: 3.8
             sphinx-version: 3.2.1
-          - python-version: pypy3
+          - python-version: pypy3.8
             sphinx-version: 3.2.1
         
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/codeqa-test.yml
+++ b/.github/workflows/codeqa-test.yml
@@ -23,15 +23,15 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         python-version: [3.6, 3.8, pypy3]
         sphinx-version: [2.4.4, 3.2.1, 5.2.3]
-      exclude:
-        - python-version: 3.8
-          sphinx-version: 2.4.4
-        - python-version: pypy3
-          sphinx-version: 2.4.4
-        - python-version: 3.8
-          sphinx-version: 3.2.1
-        - python-version: pypy3
-          sphinx-version: 3.2.1
+        exclude:
+          - python-version: 3.8
+            sphinx-version: 2.4.4
+          - python-version: pypy3
+            sphinx-version: 2.4.4
+          - python-version: 3.8
+            sphinx-version: 3.2.1
+          - python-version: pypy3
+            sphinx-version: 3.2.1
         
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/codeqa-test.yml
+++ b/.github/workflows/codeqa-test.yml
@@ -22,7 +22,17 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: [3.6, 3.8, pypy3]
-        sphinx-version: [2.4.4, 3.0.4, 3.2.1, 5.2.3]
+        sphinx-version: [2.4.4, 3.2.1, 5.2.3]
+      exclude:
+        - python-version: 3.8
+          sphinx-version: 2.4.4
+        - python-version: pypy3
+          sphinx-version: 2.4.4
+        - python-version: 3.8
+          sphinx-version: 3.2.1
+        - python-version: pypy3
+          sphinx-version: 3.2.1
+        
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/codeqa-test.yml
+++ b/.github/workflows/codeqa-test.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install sphinx

--- a/.github/workflows/codeqa-test.yml
+++ b/.github/workflows/codeqa-test.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: [3.6, 3.8, pypy3]
-        sphinx-version: [2.4.4, 3.0.4, 3.2.1]
+        sphinx-version: [2.4.4, 3.0.4, 3.2.1, 5.2.3]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     include_package_data=True,
     url="https://github.com/mattip/sphinx-affiliates",
     license="MIT",
-    python_requires=">=3.6,==2.7",
+    python_requires=">=2.7,!=3.1,!=3.2,!=3.3,!=3.4,!=3.5",
     install_requires=["sphinx>=2"],
     extras_require={
         "testing": [

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ setup(
     license="MIT",
     python_requires=">=2.7,!=3.1,!=3.2,!=3.3,!=3.4,!=3.5",
     install_requires=[
-        "sphinx>=2; python_version==2.7",
-        "sphinx>4; python_version>3.7",
+        "sphinx>=2 ; python_version=='2.7'",
+        "sphinx>4 ; python_version>'3.7'",
     ],
     extras_require={
         "testing": [

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ setup(
     include_package_data=True,
     url="https://github.com/mattip/sphinx-affiliates",
     license="MIT",
-    python_requires=">=3.6,2.7",
-    install_requires=["sphinx>=2,<4"],
+    python_requires=">=3.6,==2.7",
+    install_requires=["sphinx>=2"],
     extras_require={
         "testing": [
             "coverage",

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,10 @@ setup(
     url="https://github.com/mattip/sphinx-affiliates",
     license="MIT",
     python_requires=">=2.7,!=3.1,!=3.2,!=3.3,!=3.4,!=3.5",
-    install_requires=["sphinx>=2"],
+    install_requires=[
+        "sphinx>=2; python_version==2.7",
+        "sphinx>4; python_version>3.7",
+    ],
     extras_require={
         "testing": [
             "coverage",

--- a/sphinx_affiliates/__init__.py
+++ b/sphinx_affiliates/__init__.py
@@ -30,7 +30,7 @@ def add_affiliates(app: "Sphinx") -> None:
         with open(searchindexfn) as fid_in:
             txt = fid_in.read()
             if txt.startswith('Search.setIndex({'):
-                prefix = 'Search.setAffiliate({rootUrl="%s",' % rootUrl
+                prefix = 'Search.setAffiliate({rootUrl:"%s",' % rootUrl
                 if self.indexer_dumps_unicode:
                     with open(affiliatefn, 'w', encoding='utf-8') as fid_out:
                         fid_out.write(prefix + txt[17:])


### PR DESCRIPTION
The following error was reported by the browser

Uncaught SyntaxError: Invalid shorthand property initializer